### PR TITLE
chore: organize monitoring repo structure and reports

### DIFF
--- a/docs/.keep
+++ b/docs/.keep
@@ -1,0 +1,5 @@
+# Purpose: General documentation for the triangulum-observe repository.
+# Use this folder for:
+# - High-level guides, runbooks, and how-tos
+# - Architecture, deployment, and operational docs
+# - Notes and references that apply across monitoring solutions

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This document outlines the organization and naming conventions for the `triangul
 
 ## Repository Structure
 
-```
+```text
 triangulum-observe/
 ├── docs/                    # General documentation and guides
 ├── reports/                 # Monitoring reports and exports

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,80 @@
+# Documentation Structure
+
+This document outlines the organization and naming conventions for the `triangulum-observe` repository.
+
+## Repository Structure
+
+```
+triangulum-observe/
+├── docs/                    # General documentation and guides
+├── reports/                 # Monitoring reports and exports
+└── solutions/               # Product-specific configurations and docs
+    ├── netdata/            # Netdata-specific content
+    ├── zabbix/             # Zabbix-specific content
+    └── checkmk/            # CheckMK-specific content
+```
+
+## Directory Purposes
+
+### `docs/`
+- High-level guides, runbooks, and how-tos
+- Architecture, deployment, and operational documentation
+- Notes and references that apply across monitoring solutions
+- Repository-wide documentation and standards
+
+### `reports/`
+- Monitoring reports and dashboard exports
+- Performance summaries and insights
+- Historical data and trend analyses
+- Generated reports from various monitoring tools
+
+### `solutions/`
+- Product-specific documentation and configurations
+- Deployment guides and setup instructions
+- Templates, dashboards, and custom configurations
+- Troubleshooting guides specific to each monitoring solution
+
+## Naming Conventions
+
+To maintain CLI-friendly filenames and consistent organization:
+
+### File Naming Standards
+- **Use lowercase kebab-case**: `my-document.md`, `netdata-config.yaml`
+- **No spaces or uppercase**: Avoid `My Document.md` or `NETDATA_CONFIG.yaml`
+- **Use appropriate extensions**: `.md` for documentation, `.yaml`/`.yml` for configs
+- **Date format**: Use `YYYY-MM-DD` format for dated files (e.g., `report-2025-08-13.pdf`)
+
+### Examples
+✅ **Good**:
+- `installation-guide.md`
+- `netdata-insights-2025-08-13.pdf`
+- `zabbix-host-templates.xml`
+- `checkmk-bakery-config.yaml`
+
+❌ **Avoid**:
+- `Installation Guide.md`
+- `Netdata Insights 8_13_25.pdf`
+- `ZABBIX_HOST_TEMPLATES.XML`
+
+## Per-Directory Indexes
+
+Each solution directory should maintain its own documentation:
+
+- [`solutions/netdata/README.md`](../solutions/netdata/) - Netdata-specific guides and configs
+- [`solutions/zabbix/README.md`](../solutions/zabbix/) - Zabbix templates and procedures  
+- [`solutions/checkmk/README.md`](../solutions/checkmk/) - CheckMK site configurations
+
+## Contributing
+
+When adding new content:
+
+1. **Choose the right directory** based on scope (general docs vs. solution-specific)
+2. **Follow naming conventions** to ensure CLI-friendly filenames
+3. **Update relevant README files** to link to your new documentation
+4. **Include brief descriptions** in directory indexes for discoverability
+
+## Quick Navigation
+
+- [General Documentation](.) - Repository-wide guides and standards
+- [Monitoring Reports](../reports/) - Generated reports and exports
+- [Solution Configurations](../solutions/) - Product-specific documentation

--- a/reports/README.md
+++ b/reports/README.md
@@ -1,0 +1,75 @@
+# Monitoring Reports
+
+This directory contains monitoring reports, dashboard exports, and performance analyses from various monitoring tools.
+
+## Current Reports
+
+### Netdata Reports
+- [`netdata-insights-7d-summary-2025-08-13-all-nodes.pdf`](./netdata-insights-7d-summary-2025-08-13-all-nodes.pdf) - 7-day infrastructure summary for all monitored nodes
+
+## Report Categories
+
+### Performance Reports
+- System performance summaries and trend analyses
+- Resource utilization reports and capacity planning
+- Network performance and connectivity reports
+
+### Health Reports
+- Infrastructure health assessments
+- Service availability and uptime reports
+- Alert and incident summary reports
+
+### Compliance & Audit Reports
+- Security monitoring and compliance reports
+- Configuration drift and audit trail reports
+- Backup and disaster recovery status reports
+
+## Naming Conventions
+
+Follow these patterns for consistent, CLI-friendly report naming:
+
+### Format Pattern
+`{tool}-{report-type}-{time-period}-{date}-{scope}.{ext}`
+
+### Examples
+- `netdata-insights-7d-summary-2025-08-13-all-nodes.pdf`
+- `zabbix-availability-monthly-2025-08-web-servers.pdf`
+- `checkmk-performance-weekly-2025-08-15-database-cluster.html`
+
+### Components
+- **tool**: `netdata`, `zabbix`, `checkmk`, etc.
+- **report-type**: `insights`, `availability`, `performance`, `security`, etc.
+- **time-period**: `daily`, `weekly`, `monthly`, `7d`, `30d`, etc.
+- **date**: `YYYY-MM-DD` format
+- **scope**: `all-nodes`, `web-servers`, `database-cluster`, etc.
+- **extension**: `.pdf`, `.html`, `.csv`, `.json`, etc.
+
+## Automated Reports
+
+### Schedule & Retention
+- **Daily Reports**: Kept for 30 days
+- **Weekly Reports**: Kept for 6 months  
+- **Monthly Reports**: Kept for 2 years
+- **Quarterly Reports**: Kept indefinitely
+
+### Report Sources
+- **Netdata Cloud**: Automated exports from Netdata insights
+- **Zabbix Frontend**: Dashboard exports and custom reports
+- **CheckMK**: WATO reports and custom analytics
+- **Custom Scripts**: Automated report generation tools
+
+## Related Documentation
+
+- [General Documentation](../docs/) - Repository-wide guides
+- [Solution Configurations](../solutions/) - Tool-specific setup and configs
+- [Netdata Solutions](../solutions/netdata/) - Netdata-specific documentation
+- [Zabbix Solutions](../solutions/zabbix/) - Zabbix-specific documentation
+- [CheckMK Solutions](../solutions/checkmk/) - CheckMK-specific documentation
+
+## Contributing
+
+When adding new reports:
+- Follow the [naming conventions](#naming-conventions) above
+- Update this index with new report descriptions
+- Include brief summaries of report contents
+- Archive old reports according to retention policies

--- a/solutions/checkmk/.keep
+++ b/solutions/checkmk/.keep
@@ -1,0 +1,5 @@
+# Purpose: Checkmk-specific documentation, configurations, and integration notes.
+# Suggested contents:
+# - Site configuration, rulesets, and plugin checks
+# - Agent deployment instructions and bakery configs
+# - Dashboards, views, and alerting setup for Checkmk

--- a/solutions/checkmk/README.md
+++ b/solutions/checkmk/README.md
@@ -35,7 +35,7 @@ This directory is organized for:
 
 - [General Documentation](../../docs/) - Repository-wide guides
 - [Monitoring Reports](../../reports/) - Generated CheckMK reports
-- [Other Solutions](../) - Netdata, Zabbix, and other monitoring tools
+- [Other Solutions](../) - [Netdata](../netdata/), [Zabbix](../zabbix/), and other monitoring tools
 
 ## Contributing
 

--- a/solutions/checkmk/README.md
+++ b/solutions/checkmk/README.md
@@ -1,0 +1,46 @@
+# CheckMK Solutions
+
+This directory contains CheckMK-specific documentation, configurations, and integration notes.
+
+## Contents
+
+This directory is organized for:
+
+- **Site Configuration** - CheckMK site setup and configuration files
+- **Rulesets & Rules** - Host and service configuration rules
+- **Plugin Checks** - Custom check plugins and monitoring extensions
+- **Agent Deployment** - Agent installation and deployment procedures
+- **Bakery Configurations** - Agent bakery recipes and custom packages
+- **Dashboards & Views** - Custom dashboards, views, and visualizations
+- **Alerting Setup** - Notification rules and escalation configurations
+- **Troubleshooting Guides** - Common issues and resolution procedures
+
+## Quick Start
+
+1. Set up CheckMK site configuration
+2. Deploy agents using bakery or manual installation
+3. Configure rulesets for your infrastructure
+4. Set up custom checks and plugins as needed
+5. Create dashboards and configure alerting
+
+## Configuration Areas
+
+- **Host & Service Rules** - Monitoring configuration and thresholds
+- **Agent Plugins** - Custom monitoring plugins and scripts
+- **WATO Configuration** - Web-based administration and setup
+- **Event Console** - Log monitoring and event correlation
+- **Business Intelligence** - Service dependency and BI rules
+
+## Related Documentation
+
+- [General Documentation](../../docs/) - Repository-wide guides
+- [Monitoring Reports](../../reports/) - Generated CheckMK reports
+- [Other Solutions](../) - Netdata, Zabbix, and other monitoring tools
+
+## Contributing
+
+When adding CheckMK-specific content:
+- Follow the [naming conventions](../../docs/README.md#naming-conventions)
+- Include MKP packages for plugins and extensions
+- Document configuration steps and dependencies
+- Update this index with links to new configurations and guides

--- a/solutions/netdata/.keep
+++ b/solutions/netdata/.keep
@@ -1,0 +1,5 @@
+# Purpose: Netdata-specific documentation, configurations, and integration notes.
+# Suggested contents:
+# - Netdata deployment and configuration guides
+# - Exporters/collectors settings and dashboards
+# - Tuning, troubleshooting, and runbooks specific to Netdata

--- a/solutions/netdata/.keep
+++ b/solutions/netdata/.keep
@@ -3,3 +3,10 @@
 # - Netdata deployment and configuration guides
 # - Exporters/collectors settings and dashboards
 # - Tuning, troubleshooting, and runbooks specific to Netdata
+
+# Netdata 7-Day Summary Report
+# Location: reports/netdata-insights-7d-summary-<YYYY-MM-DD>-all-nodes.pdf
+# Example:
+#   ./scripts/generate-netdata-report.sh \
+#     --period 7d \
+#     --output reports/netdata-insights-7d-summary-$(date +%F)-all-nodes.pdf

--- a/solutions/netdata/README.md
+++ b/solutions/netdata/README.md
@@ -26,7 +26,7 @@ This directory is organized for:
 
 - [General Documentation](../../docs/) - Repository-wide guides
 - [Monitoring Reports](../../reports/) - Generated Netdata reports
-- [Other Solutions](../) - Zabbix, CheckMK, and other monitoring tools
+- [Other Solutions](../) - [Zabbix](../zabbix/), [CheckMK](../checkmk/), and other monitoring tools
 
 ## Contributing
 

--- a/solutions/netdata/README.md
+++ b/solutions/netdata/README.md
@@ -1,0 +1,36 @@
+# Netdata Solutions
+
+This directory contains Netdata-specific documentation, configurations, and integration notes.
+
+## Contents
+
+This directory is organized for:
+
+- **Deployment Guides** - Installation and setup procedures for Netdata
+- **Configuration Files** - Agent configs, collectors, and custom settings
+- **Dashboard Exports** - Custom dashboards and visualization templates
+- **Collectors & Exporters** - Custom collectors and external data integrations
+- **Tuning & Optimization** - Performance tuning and resource optimization guides
+- **Troubleshooting** - Common issues and resolution procedures
+- **Runbooks** - Operational procedures specific to Netdata
+
+## Quick Start
+
+1. Review deployment guides for your environment
+2. Configure agents using the provided templates
+3. Set up collectors for your specific monitoring needs
+4. Import dashboard templates
+5. Configure alerting and notifications
+
+## Related Documentation
+
+- [General Documentation](../../docs/) - Repository-wide guides
+- [Monitoring Reports](../../reports/) - Generated Netdata reports
+- [Other Solutions](../) - Zabbix, CheckMK, and other monitoring tools
+
+## Contributing
+
+When adding Netdata-specific content:
+- Follow the [naming conventions](../../docs/README.md#naming-conventions)
+- Update this index with links to new documentation
+- Include examples and practical use cases

--- a/solutions/zabbix/.keep
+++ b/solutions/zabbix/.keep
@@ -1,0 +1,5 @@
+# Purpose: Zabbix-specific documentation, configurations, and integration notes.
+# Suggested contents:
+# - Host templates, item/trigger prototypes, and dashboard exports
+# - Agent/proxy/server configuration and tuning
+# - Troubleshooting and operational procedures for Zabbix

--- a/solutions/zabbix/README.md
+++ b/solutions/zabbix/README.md
@@ -34,7 +34,7 @@ This directory is organized for:
 
 - [General Documentation](../../docs/) - Repository-wide guides
 - [Monitoring Reports](../../reports/) - Generated Zabbix reports
-- [Other Solutions](../) - Netdata, CheckMK, and other monitoring tools
+- [Other Solutions](../) - [Netdata](../netdata/), [CheckMK](../checkmk/), and other monitoring tools
 
 ## Contributing
 

--- a/solutions/zabbix/README.md
+++ b/solutions/zabbix/README.md
@@ -1,0 +1,45 @@
+# Zabbix Solutions
+
+This directory contains Zabbix-specific documentation, configurations, and integration notes.
+
+## Contents
+
+This directory is organized for:
+
+- **Host Templates** - Template exports and custom monitoring templates
+- **Item & Trigger Prototypes** - Monitoring item definitions and alert triggers
+- **Dashboard Exports** - Custom dashboards and screen configurations
+- **Agent Configurations** - Zabbix agent and proxy configuration files
+- **Server Configuration** - Zabbix server setup and tuning parameters
+- **Scripts & Integrations** - Custom scripts and external integrations
+- **Troubleshooting Guides** - Common issues and resolution procedures
+- **Operational Procedures** - Maintenance and administrative runbooks
+
+## Quick Start
+
+1. Import relevant host templates for your infrastructure
+2. Configure Zabbix agents on monitored hosts
+3. Set up custom items and triggers as needed
+4. Import dashboard configurations
+5. Configure notification channels and escalation rules
+
+## Template Categories
+
+- **Operating Systems** - Linux, Windows, macOS monitoring templates
+- **Applications** - Database, web server, and application-specific templates
+- **Network Devices** - Switch, router, and network infrastructure templates
+- **Cloud Services** - AWS, Azure, GCP monitoring integrations
+
+## Related Documentation
+
+- [General Documentation](../../docs/) - Repository-wide guides
+- [Monitoring Reports](../../reports/) - Generated Zabbix reports
+- [Other Solutions](../) - Netdata, CheckMK, and other monitoring tools
+
+## Contributing
+
+When adding Zabbix-specific content:
+- Follow the [naming conventions](../../docs/README.md#naming-conventions)
+- Include template XML exports with descriptive names
+- Document any dependencies or prerequisites
+- Update this index with links to new templates and guides


### PR DESCRIPTION
Renamed Netdata 7d summary report to CLI-friendly format, created docs/reports/solutions structure with product subdirectories, moved report to reports/, and added .keep files documenting folder purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added repository-wide documentation guidelines covering structure, naming conventions, contribution process, and per-directory indexes.
  - Added monitoring reports guidance with report types, naming pattern, schedules, retention, and a sample Netdata report.
  - Added solution-specific placeholders and READMEs for Checkmk, Netdata, and Zabbix outlining recommended contents: deployment, configuration, dashboards, alerting, troubleshooting, and runbooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->